### PR TITLE
Set necessary services to be available in run levels 2,3,4,5

### DIFF
--- a/provision/salt/cacheserver.sls
+++ b/provision/salt/cacheserver.sls
@@ -16,3 +16,10 @@ memcached:
   service.running:
     - require:
       - pkg: memcached
+
+# Set memcached to run in levels 2345.
+memcached-init:
+  cmd.run:
+    - name: chkconfig --level 2345 memcached on
+    - require:
+      - pkg: memcached

--- a/provision/salt/dbserver.sls
+++ b/provision/salt/dbserver.sls
@@ -42,6 +42,13 @@ mysql:
       - mysql-server
       - MySQL-python
 
+# Set MySQL to run in levels 2345.
+mysqld-init:
+  cmd.run:
+    - name: chkconfig --level 2345 mysqld on
+    - require:
+      - pkg: mysql
+
 /etc/my.cnf:
   file.managed:
     - source: salt://config/mysql/my.cnf

--- a/provision/salt/webserver.sls
+++ b/provision/salt/webserver.sls
@@ -45,6 +45,13 @@ nginx:
       - file: /etc/nginx/sites-enabled/default
       - file: /etc/nginx/sites-enabled/wp.wsu.edu.conf
 
+# Set Nginx to run in levels 2345.
+nginx-init:
+  cmd.run:
+    - name: chkconfig --level 2345 nginx on
+    - require:
+      - pkg: nginx
+
 php-fpm:
   pkg.installed:
     - pkgs:
@@ -64,6 +71,13 @@ php-fpm:
       - pkg: php-fpm
     - watch:
       - file: /etc/php-fpm.d/www.conf
+
+# Set php-fpm to run in levels 2345.
+php-fpm-init:
+  cmd.run:
+    - name: chkconfig --level 2345 php-fpm on
+    - require:
+      - pkg: php-fpm
 
 ImageMagick:
   pkg.installed:


### PR DESCRIPTION
php-fpm, nginx, memcached, and mysqld should all be running when a provisioned machine boots.
