### PR TITLE
Mounted /var/www/ loses www-data permissions on next `vagrant up`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,11 @@ Vagrant.configure("2") do |config|
   # Mount the local project's www/ directory as /var/www inside the virtual machine. This will
   # be mounted as the 'vagrant' user at first, then unmounted and mounted again as 'www-data'
   # during provisioning.
-  config.vm.synced_folder "www", "/var/www", :mount_options => [ "dmode=775", "fmode=774" ]
+  if machine_exists
+    config.vm.synced_folder "www", "/var/www", owner: 'www-data', group: 'www-data', :mount_options => [ "dmode=775", "fmode=774" ]
+  else
+    config.vm.synced_folder "www", "/var/www", :mount_options => [ "dmode=775", "fmode=774" ]
+  end
 
   # Local Machine Hosts
   #


### PR DESCRIPTION
Vagrant allows us to specify a user to mount shared folders with. We would normally mount `/var/www/` as the `www-data` user, but in the CentOS box that we're using, this user isn't available until the machine has been provisioned.

We trick things a bit during provisioning by unmounting the `vagrant` owned `/var/www/` and remounting it under the `www-data` user.

When `vagrant halt` is used with `vagrant up`, the drive is remounted as defined in Vagrantfile and our provisioning is not processed again (which is good).

Need to determine how best to handle the remount as the `www-data` user.
