### PR TITLE
[NO MERGE] Explore vagrant-hostmanager for guest and host /etc/hosts management

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,80 +14,84 @@ machines_file = File.expand_path(File.dirname(__FILE__) + '/.vagrant/machines/de
 machine_exists = File.file?(machines_file)
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
 
-Vagrant.configure("2") do |config|
-  # Virtualbox specific setting to allocate 512MB of memory to the virtual machine.
-  config.vm.provider :virtualbox do |v|
-    v.customize ["modifyvm", :id, "--memory", 512]
-  end
-
-  # CentOS 6.4, 64 bit release
-  #
-  # Provides a fairly bare-bones CentOS box created by Puppet Labs.
-  config.vm.box     = "centos-64-x64-puppetlabs"
-  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box"
-
-  # Set the default hostname and IP address for the virtual machine. If you have any other
-  # Vagrant environments on the 10.10.30.x subnet, you may want to consider modifying this.
-  config.vm.hostname = "wsuwp"
-  config.vm.network :private_network, ip: "10.10.30.30"
-
-  # Mount the local project's www/ directory as /var/www inside the virtual machine.
-  config.vm.synced_folder "www", "/var/www", :mount_options => [ "uid=510,gid=510", "dmode=775", "fmode=774" ]
-
-  # Local Machine Hosts
-  #
-  # If the Vagrant plugin hostsupdater (https://github.com/cogitatio/vagrant-hostsupdater) is
-  # installed, the following will automatically configure your local machine's hosts file to
-  # be aware of the domains specified below. Watch the provisioning script as you may be
-  # required to enter a password for Vagrant to access your hosts file.
-  #
-  # Only the default domain, wp.wsu.edu, is provided. Add a `custom-hosts` file to this Vagrant
-  # directory and provide additional hosts there. These should be added as one host per line.
-  if defined? VagrantPlugins::HostsUpdater
-    hosts = [ "wp.wsu.edu" ]
-
-    paths = []
-    Dir.glob(vagrant_dir + '/custom-hosts').each do |path|
-      paths << path
+Vagrant.configure("2") do |wsuwpconfig|
+  wsuwpconfig.vm.define :wsuwp do |config|
+    # Virtualbox specific setting to allocate 512MB of memory to the virtual machine.
+    config.vm.provider :virtualbox do |v|
+      v.customize ["modifyvm", :id, "--memory", 512]
     end
 
-    # Parse through the `custom-hosts` files in each of the found paths and put the hosts
-    # that are found into a single array.
-    paths.each do |path|
-      new_hosts = []
-      file_hosts = IO.read(path).split( "\n" )
-      file_hosts.each do |line|
-        if line[0..0] != "#"
-          new_hosts << line
-        end
+    # CentOS 6.4, 64 bit release
+    #
+    # Provides a fairly bare-bones CentOS box created by Puppet Labs.
+    config.vm.box     = "centos-64-x64-puppetlabs"
+    config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/centos-64-x64-vbox4210-nocm.box"
+
+    # Set the default hostname and IP address for the virtual machine. If you have any other
+    # Vagrant environments on the 10.10.30.x subnet, you may want to consider modifying this.
+    config.vm.hostname = "wsuwp"
+    config.vm.network :private_network, ip: "10.10.30.30"
+
+    # Mount the local project's www/ directory as /var/www inside the virtual machine.
+    config.vm.synced_folder "www", "/var/www", :mount_options => [ "uid=510,gid=510", "dmode=775", "fmode=774" ]
+
+    # Local Machine Hosts
+    #
+    # If the Vagrant plugin hostsupdater (https://github.com/cogitatio/vagrant-hostsupdater) is
+    # installed, the following will automatically configure your local machine's hosts file to
+    # be aware of the domains specified below. Watch the provisioning script as you may be
+    # required to enter a password for Vagrant to access your hosts file.
+    #
+    # Only the default domain, wp.wsu.edu, is provided. Add a `custom-hosts` file to this Vagrant
+    # directory and provide additional hosts there. These should be added as one host per line.
+    if defined? VagrantPlugins::HostsUpdater
+      hosts = [ "wp.wsu.edu" ]
+
+      paths = []
+      Dir.glob(vagrant_dir + '/custom-hosts').each do |path|
+        paths << path
       end
-      hosts.concat new_hosts
+
+      # Parse through the `custom-hosts` files in each of the found paths and put the hosts
+      # that are found into a single array.
+      paths.each do |path|
+        new_hosts = []
+        file_hosts = IO.read(path).split( "\n" )
+        file_hosts.each do |line|
+          if line[0..0] != "#"
+            new_hosts << line
+          end
+        end
+        hosts.concat new_hosts
+      end
+
+      config.hostsupdater.aliases = hosts
+      abort("hi")
     end
 
-    config.hostsupdater.aliases = hosts
-  end
+    if defined? VagrantPlugins::HostManager
+      config.hostmanager.enabled = true
+      config.hostmanager.manage_host = true
+      config.hostmanager.aliases = %w(test-alias)
+    end
 
-  if defined? VagrantPlugins::HostManager
-    config.hostmanager.include_offline = true
-    config.hostmanager.aliases = [ "test.domain.com" ]
-  end
+    # Salt Provisioning
+    #
+    # Map the provisioning directory to the guest machine and initiate the provisioning process
+    # with salt. On the first build of a virtual machine, if Salt has not yet been installed, it
+    # will be bootstrapped automatically. We have provided a modified local bootstrap script to
+    # avoid network connectivity issues and to specify that a newer version of Salt be installed.
+    #config.vm.synced_folder "provision/salt", "/srv/salt"
 
-  # Salt Provisioning
-  #
-  # Map the provisioning directory to the guest machine and initiate the provisioning process
-  # with salt. On the first build of a virtual machine, if Salt has not yet been installed, it
-  # will be bootstrapped automatically. We have provided a modified local bootstrap script to
-  # avoid network connectivity issues and to specify that a newer version of Salt be installed.
-  config.vm.synced_folder "provision/salt", "/srv/salt"
+    #config.vm.provision "shell",
+    #  inline: "cp /srv/salt/config/yum.conf /etc/yum.conf"
 
-  config.vm.provision "shell",
-    inline: "cp /srv/salt/config/yum.conf /etc/yum.conf"
-
-  config.vm.provision :salt do |salt|
-    salt.bootstrap_script = 'provision/bootstrap_salt.sh'
-    salt.install_type = 'testing'
-    salt.verbose = true
-    salt.minion_config = 'provision/salt/minions/vagrant.conf'
-    salt.run_highstate = true
+    #config.vm.provision :salt do |salt|
+    #  salt.bootstrap_script = 'provision/bootstrap_salt.sh'
+    #  salt.install_type = 'testing'
+    #  salt.verbose = true
+    #  salt.minion_config = 'provision/salt/minions/vagrant.conf'
+    #  salt.run_highstate = true
+    #end
   end
 end

--- a/provision/salt/webserver.sls
+++ b/provision/salt/webserver.sls
@@ -13,13 +13,6 @@ user-www-data:
     - require:
       - group: www-data
 
-/etc/hosts:
-  file.managed:
-    - source: salt://config/hosts
-    - user: root
-    - group: root
-    - mode: 644
-
 /etc/resolv.conf:
   file.managed:
     - source: salt://config/resolv.conf


### PR DESCRIPTION
Reasons:
1. vagrant-hostmanager seems to be under more active development
2. I've seen multiple strange issues from vagrant-hostsupdater recently
3. It may be worth supporting either/or in the future. Familiarity is good anyway.
