### PR TITLE
Remove WSU DNS from default setup

### DIFF
--- a/provision/salt/config/resolv.conf
+++ b/provision/salt/config/resolv.conf
@@ -1,7 +1,9 @@
-# WSU Nameservers should be primary.
-nameserver 134.121.139.10
-nameserver 134.121.80.36
-
-# Google DNS servers are a backup.
+# Default DNS servers to use inside the virtual machine.
+#
+# We use Google right now as it is a pretty common set and
+# will work for just about everyone. In the future it would
+# be nice to allow custom nameservers to be set.
+#
+# Google DNS servers
 nameserver 8.8.8.8
 nameserver 8.8.4.4


### PR DESCRIPTION
In 4a5101516, I added WSU nameservers to make DNS lookups on campus go faster for a few things. Not entirely sure why I thought that was a great idea. The commit message even mentions how we'll need to abstract it.

We should continue to use Google DNS by default, as it should be stable enough to route us where we need to go.

In the future, we'll want to abstract this a bit and allow DNS inside the VM to be a customizable thing. This would allow other orgs (and us) to choose.
