### PR TITLE
Clarify project specific server roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 This repository contains provisioning for the Linux servers maintained by WSU Web Communication.
 
 * [Salt](http://www.saltstack.com/community/) is used to manage configuration and provisioning.
+
+## Minion Config
+
+Minions exist in `provision/salt/minions/` and are used to specify a configuration specific to a server during provisioning.
+
+Naming of the minions should follow a `project` `-` `location` format.
+
+Current minions include:
+
+* `wsuwp-production.conf` for the production environment of the WSUWP Platform.
+* `wsuwp-vagrant.conf` for the development environment of the WSUWP Platform.
+* `wsuwp-indie-production.conf` for the production environment for the server containing individual WordPress sites.
+* `wsuwp-indie-vagrant.conf` for the development environment containing individual WordPress sites.


### PR DESCRIPTION
Project specific roles should be clarified so that it is easier to maintain the requirements of multiple server configurations in this repository.

We'll need to best determine the naming for this as we go.
- `project-environment.conf` could specify something like `wsuwp-production.conf` for provisioning a server to run WSUWP in production. If this differs in any way from the requirements in the local machine, `wsuwp-vagrant.conf` can be used as a separate role.
- In an ideal world, a role specified with `project.conf` would work in both production and development, though this may not always be the case because of mapped drive locations, etc.
