### PR TITLE
Use phar installation for instances where we setup wp-cli

### DIFF
--- a/provision/salt/wsuwp-dev.sls
+++ b/provision/salt/wsuwp-dev.sls
@@ -6,16 +6,11 @@
 # Install wp-cli to provide a way to manage WordPress at the command line.
 wp-cli:
   cmd.run:
-    - name: curl https://raw.github.com/wp-cli/wp-cli.github.com/master/installer.sh | bash
+    - name: curl -L https://github.com/wp-cli/wp-cli/releases/download/v0.13.0/wp-cli.phar > wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/bin/wp
     - cwd: /home/vagrant/
     - unless: which wp
-    - user: vagrant
     - require:
       - pkg: php-fpm
-      - pkg: git
-  file.symlink:
-    - name: /usr/bin/wp
-    - target: /home/vagrant/.wp-cli/bin/wp
 
 # Setup the MySQL requirements for WSUWP Platform
 #

--- a/provision/salt/wsuwp-indie-dev.sls
+++ b/provision/salt/wsuwp-indie-dev.sls
@@ -6,15 +6,10 @@
 # Install wp-cli to provide a way to manage WordPress at the command line.
 wp-cli:
   cmd.run:
-    - name: curl https://raw.github.com/wp-cli/wp-cli.github.com/master/installer.sh | bash
+    - name: curl -L https://github.com/wp-cli/wp-cli/releases/download/v0.13.0/wp-cli.phar > wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/bin/wp
     - unless: which wp
-    - user: vagrant
     - require:
       - pkg: php-fpm
-      - pkg: git
-  file.symlink:
-    - name: /usr/bin/wp
-    - target: /home/vagrant/.wp-cli/bin/wp
 
 wsuwp-indie-db:
   mysql_user.present:


### PR DESCRIPTION
The shell based install via GitHub with composer takes several minutes. The phar download takes several seconds.
