### PR TITLE
[PR] Introduce security.sls state file

### DIFF
--- a/provision/salt/security.sls
+++ b/provision/salt/security.sls
@@ -1,0 +1,13 @@
+iptables:
+  pkg.installed:
+    - name: iptables
+  service.running:
+    - watch:
+      - file: /etc/sysconfig/iptables
+
+/etc/sysconfig/iptables:
+  file.managed:
+    - source: salt://config/iptables/iptables
+    - user: root
+    - group: root
+    - mode: 600

--- a/provision/salt/top.sls
+++ b/provision/salt/top.sls
@@ -9,6 +9,7 @@
 base:
   '*':
     - server
+    - security
     - webserver
     - cacheserver
     - dbserver

--- a/provision/salt/webserver.sls
+++ b/provision/salt/webserver.sls
@@ -75,13 +75,6 @@ ImageMagick:
       - php-pecl-imagick
       - ImageMagick
 
-iptables:
-  pkg.installed:
-    - name: iptables
-  service.running:
-    - watch:
-      - file: /etc/sysconfig/iptables
-
 /etc/nginx/nginx.conf:
   file.managed:
     - source: salt://config/nginx/nginx.conf
@@ -132,10 +125,3 @@ iptables:
     - mode: 644
     - require:
       - pkg: php-fpm
-
-/etc/sysconfig/iptables:
-  file.managed:
-    - source: salt://config/iptables/iptables
-    - user: root
-    - group: root
-    - mode: 600


### PR DESCRIPTION
Moves the iptables configuration from webserver.sls to a more appropriate place and sets us up for future security management
