### PR TITLE
[PR] Set SCRIPT_DEBUG to true in local WordPress environments

### DIFF
--- a/provision/salt/config/wordpress/wp-config.php.jinja
+++ b/provision/salt/config/wordpress/wp-config.php.jinja
@@ -31,8 +31,9 @@ define('NONCE_SALT',       'makethisuniqueonproduction');
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/wp-content' );
 
 {% if pillar['network']['location'] == 'local' %}
-define( 'WP_DEBUG',    true  );
-define( 'SAVEQUERIES', true  );
+define( 'WP_DEBUG',     true  );
+define( 'SAVEQUERIES',  true  );
+define( 'SCRIPT_DEBUG', true  );
 {% else %}
 define( 'WP_DEBUG',    false );
 define( 'SAVEQUERIES', false );


### PR DESCRIPTION
This will help when debugging Javascript related issues as things like load-script.php will not be used for concatenation.
