### PR TITLE
[PR] Add DROP privileges to default WP DB users

### DIFF
--- a/provision/salt/wordpress.sls
+++ b/provision/salt/wordpress.sls
@@ -65,7 +65,7 @@ wsuwp-indie-db-{{ site }}:
       - pkg: mysql
       - sls: dbserver
   mysql_grants.present:
-    - grant: select, insert, create, update, delete, alter
+    - grant: select, insert, create, update, delete, alter, drop
     - database: {{ site_args['database'] }}.*
     - user: {{ site_args['db_user'] }}
     - host: {{ site_args['db_host'] }}


### PR DESCRIPTION
This may change in production at a later time, but can be useful
in development immediately.
