### PR TITLE
[PR] Remove support for unsupported Chrome Frame

### DIFF
--- a/provision/salt/config/nginx/nginx.conf.jinja
+++ b/provision/salt/config/nginx/nginx.conf.jinja
@@ -108,8 +108,8 @@ http {
     # content-type.
     add_header X-Content-Type-Options nosniff;
 
-    # Use the highest mode available to a version of IE and support chrome frame.
-    add_header X-UA-Compatible IE=Edge,chrome=1;
+    # Use the highest mode available to a version of IE.
+    add_header X-UA-Compatible IE=Edge;
 
     # Enable the XSS filter built into modern web browsers. This will re-enable
     # the XSS filter if a user has disabled it.


### PR DESCRIPTION
Google officially retired Chrome Frame, with support ending in January
of this year - http://blog.chromium.org/2013/06/retiring-chrome-frame.html
