### PR TITLE
[PR] Uncomment listen.mode to resolve 502 issue in PHP 5.5.12

### DIFF
--- a/provision/salt/config/php-fpm/www.conf
+++ b/provision/salt/config/php-fpm/www.conf
@@ -43,8 +43,8 @@ listen = /var/run/php5-fpm.sock
 ;                 mode is set to 0666
 ;listen.owner = www-data
 ;listen.group = www-data
-;listen.mode = 0666
- 
+listen.mode = 0666
+
 ; List of ipv4 addresses of FastCGI clients which are allowed to connect.
 ; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
 ; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address


### PR DESCRIPTION
I'm not entirely sure why this issue arose all of a sudden, but it
seems that PHP wants this uncommented now.
