### PR TITLE
[PR] Upgrade to ngx_pagespeed 1.8.31.4-beta

### DIFF
--- a/provision/salt/config/nginx/compile-nginx.sh
+++ b/provision/salt/config/nginx/compile-nginx.sh
@@ -3,7 +3,7 @@
 # Compile Nginx with SPDY and Pagespeed support.
 rm -fr /tmp/nginx-1.7.2
 rm -fr /tmp/openssl-1.0.1h
-rm -fr /tmp/ngx_pagespeed-1.8.31.3-beta
+rm -fr /tmp/ngx_pagespeed-1.8.31.4-beta
 
 # Compile against OpenSSL to enable NPN.
 cd /tmp/
@@ -12,11 +12,11 @@ tar -xzvf openssl-1.0.1h.tar.gz
 
 # Provide the PageSpeed module for Nginx.
 cd /tmp/
-wget https://github.com/pagespeed/ngx_pagespeed/archive/v1.8.31.3-beta.zip
-unzip v1.8.31.3-beta
-cd /tmp/ngx_pagespeed-1.8.31.3-beta/
-wget https://dl.google.com/dl/page-speed/psol/1.8.31.3.tar.gz
-tar -xzvf 1.8.31.3.tar.gz # expands to psol/
+wget https://github.com/pagespeed/ngx_pagespeed/archive/v1.8.31.4-beta.zip
+unzip v1.8.31.4-beta
+cd /tmp/ngx_pagespeed-1.8.31.4-beta/
+wget https://dl.google.com/dl/page-speed/psol/1.8.31.4.tar.gz
+tar -xzvf 1.8.31.4.tar.gz # expands to psol/
 
 # Get the Nginx source.
 #
@@ -60,7 +60,7 @@ cd /tmp/nginx-1.7.2
 --with-cc-opt='-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2' \
 --with-ld-opt='-Wl,-z,relro -Wl,--as-needed' \
 --with-openssl=/tmp/openssl-1.0.1h \
---add-module=/tmp/ngx_pagespeed-1.8.31.3-beta
+--add-module=/tmp/ngx_pagespeed-1.8.31.4-beta
 
 cd /tmp/nginx-1.7.2
 make

--- a/provision/salt/webserver.sls
+++ b/provision/salt/webserver.sls
@@ -63,7 +63,7 @@ nginx:
   cmd.run:
     - name: sh nginx-compile.sh
     - cwd: /root/
-    - unless: nginx -V &> nginx-version.txt && cat nginx-version.txt | grep -A 42 "nginx/1.7.2" | grep "openssl-1.0.1h" | grep "ngx_pagespeed-1.8.31.3-beta"
+    - unless: nginx -V &> nginx-version.txt && cat nginx-version.txt | grep -A 42 "nginx/1.7.2" | grep "openssl-1.0.1h" | grep "ngx_pagespeed-1.8.31.4-beta"
     - require:
       - file: /root/nginx-compile.sh
       - user: www-data


### PR DESCRIPTION
This corrects a vulnerability in the version of OpenSSL used by ngx_pagespeed - http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0224

We aren't using HTTPS fetching in pagespeed yet, so this is mainly cautionary.
