### PR TITLE
[PR] Disable default enforcement of HSTS, we'll move to site by site

### DIFF
--- a/provision/salt/config/nginx/wsuwp-ssl-common.conf
+++ b/provision/salt/config/nginx/wsuwp-ssl-common.conf
@@ -23,4 +23,4 @@ spdy_headers_comp 6;
 add_header Alternate-Protocol 443:npn-spdy/3,443:npn-spdy/2;
 
 # Enable HTTP Strict Transport Security (HSTS)
-add_header Strict-Transport-Security "max-age=31536000;";
+# add_header Strict-Transport-Security "max-age=31536000;";


### PR DESCRIPTION
We can't guarantee yet that all assets are ready for HTTPS on
front end views, only back end views. Until we can, HSTS doesn't
really work for us
