### PR TITLE
[PR] Revert "Remove support for unsupported Chrome Frame"

### DIFF
--- a/provision/salt/config/nginx/nginx.conf.jinja
+++ b/provision/salt/config/nginx/nginx.conf.jinja
@@ -112,8 +112,8 @@ http {
     # content-type.
     add_header X-Content-Type-Options nosniff;
 
-    # Use the highest mode available to a version of IE.
-    add_header X-UA-Compatible IE=Edge;
+    # Use the highest mode available to a version of IE and support chrome frame.
+    add_header X-UA-Compatible IE=Edge,chrome=1;
 
     # Enable the XSS filter built into modern web browsers. This will re-enable
     # the XSS filter if a user has disabled it.


### PR DESCRIPTION
Turns out we actually do support Chrome frame.

This reverts commit ba5b5c6346d24c6c5ab33c9be0ea8f800f5f7388.
