### PR TITLE
[PR] Bump server_names_max_hash_size to 4096

### DIFF
--- a/provision/salt/config/nginx/nginx.conf.jinja
+++ b/provision/salt/config/nginx/nginx.conf.jinja
@@ -44,7 +44,7 @@ http {
 
     # We run many domain names on a single server and need a hash
     # bucket that is big enough.
-    server_names_hash_max_size 2048;
+    server_names_hash_max_size 4096;
 
     # Don't send out partial TCP frames
     tcp_nopush          on;


### PR DESCRIPTION
This should be pillar data so that it can be specified on
individual servers. Hopefully this is the last large bump. :)
