### PR TITLE
[PR] Set PHP request_slowlog_timeout to 20 seconds rather than 1

### DIFF
--- a/provision/salt/config/php-fpm/www.conf
+++ b/provision/salt/config/php-fpm/www.conf
@@ -300,7 +300,7 @@ slowlog = /var/log/php-fpm/$pool.log.slow
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_slowlog_timeout = 1
+request_slowlog_timeout = 20
  
 ; The timeout for serving a single request after which the worker process will
 ; be killed. This option should be used when the 'max_execution_time' ini option


### PR DESCRIPTION
1 second is a pretty short time. :)
