### PR TITLE
[PR] Additional default configuration for MySQL

### DIFF
--- a/provision/salt/config/mysql/my.cnf.jinja
+++ b/provision/salt/config/mysql/my.cnf.jinja
@@ -42,6 +42,13 @@ max_allowed_packet = {{ salt['pillar.get']('mysql-config:max_allowed_packet', '1
 thread_stack       = {{ salt['pillar.get']('mysql-config:thread_stack', '192K') }}
 thread_cache_size  = {{ salt['pillar.get']('mysql-config:thread_cache_size', '8') }}
 
+tmp_table_size      = {{ salt['pillar.get']('mysql-config:tmp_table_size', '16M') }}
+max_heap_table_size = {{ salt['pillar.get']('mysql-config:max_heap_table_size', '16M') }}
+table_open_cache    = {{ salt['pillar.get']('mysql-config:table_open_cache'), '400') }}
+
+# The InnoDB buffer pool size should be larger than the amount of data if possible.
+innodb_buffer_pool_size = {{ salt['pillar.get']('mysql-config:innodb_buffer_pool_size'), '128M') }}
+
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched
 myisam-recover = BACKUP


### PR DESCRIPTION
Sets a default for:
- `tmp_table_size`
- `max_heap_table_size`
- `table_open_cache`
- `innodb_buffer_pool_size`

These can be overridden in pillar data on individual instances
