### PR TITLE
[PR] Use the FTP link for OpenSSL rather than the HTTPS link (temp)

### DIFF
--- a/provision/salt/config/nginx/compile-nginx.sh
+++ b/provision/salt/config/nginx/compile-nginx.sh
@@ -7,7 +7,7 @@ rm -fr /tmp/ngx_pagespeed-1.9.32.2-beta
 
 # Compile against OpenSSL to enable NPN.
 cd /tmp/
-wget https://www.openssl.org/source/openssl-1.0.1j.tar.gz
+wget ftp://ftp.openssl.org/source/openssl-1.0.1j.tar.gz
 tar -xzvf openssl-1.0.1j.tar.gz
 
 # Provide the PageSpeed module for Nginx.


### PR DESCRIPTION
The HTTPS link is currently 404ing
