### PR TITLE
[PR] Add basic support for a JIRA configuration

### DIFF
--- a/provision/salt/jira.sls
+++ b/provision/salt/jira.sls
@@ -1,0 +1,26 @@
+# Setup the MySQL requirements for JIRA by pulling from pillar data
+# in network.sls
+jira-db:
+  mysql_user.present:
+    - name: {{ pillar['jira-config']['db_user'] }}
+    - password: {{ pillar['jira-config']['db_pass'] }}
+    - host: {{ pillar['jira-config']['db_host'] }}
+    - require:
+      - service: mysqld
+      - pkg: mysql
+      - sls: dbserver
+  mysql_database.present:
+    - name: {{ pillar['jira-config']['database'] }}
+    - require:
+      - service: mysqld
+      - pkg: mysql
+      - sls: dbserver
+  mysql_grants.present:
+    - grant: select, insert, update, delete, create, alter, drop
+    - database: {{ pillar['jira-config']['database'] }}.*
+    - user: {{ pillar['jira-config']['db_user'] }}
+    - host: {{ pillar['jira-config']['db_host'] }}
+    - require:
+      - service: mysqld
+      - pkg: mysql
+      - sls: dbserver

--- a/provision/salt/minions/wsu-search.conf
+++ b/provision/salt/minions/wsu-search.conf
@@ -16,3 +16,10 @@ pillar_roots:
 # A `mixed` state output shows one liners when states are
 # successful and larger messages when they return false.
 state_output: mixed
+
+# These settings are required for states like mysql_user.present
+# to work via the python libraries used by Salt
+mysql.host: 'localhost'
+mysql.port: 3306
+mysql.db: 'mysql'
+mysql.unix_socket: '/var/lib/mysql/mysql.sock'

--- a/provision/salt/top.sls
+++ b/provision/salt/top.sls
@@ -25,6 +25,8 @@ base:
     - wsuwp
   'wsusearch*':
     - search
+    - dbserver
+    - jira
   'wsu-lists*':
     - webserver
     - dbserver


### PR DESCRIPTION
JIRA will be installed manually on the Elasticsearch server, but we need to have a database available. We'll be using this as evaluation first and reserve the right to move it to its own server. At that point this extra provisioning may disappear.