### PR TITLE
[PR] Start the fail2ban service with the client command

### DIFF
--- a/provision/salt/security.sls
+++ b/provision/salt/security.sls
@@ -15,9 +15,6 @@ iptables:
 fail2ban:
   pkg.latest:
     - name: fail2ban
-  service.running:
-    - watch:
-      - file: /etc/fail2ban/filter.d/wordpress.conf
 
 /etc/fail2ban/jail.d/:
   file.directory:
@@ -46,3 +43,11 @@ fail2ban:
 /etc/fail2ban/jail.d/wordpress.conf:
   file.managed:
     - source: salt://config/fail2ban/jail.wordpress.conf
+
+# Start the fail2ban service as root.
+fail2ban-init:
+  cmd.run:
+    - name: fail2ban-client start
+    - cwd: /
+    - require:
+      - pkg: fail2ban

--- a/provision/salt/security.sls
+++ b/provision/salt/security.sls
@@ -12,10 +12,14 @@ iptables:
     - group: root
     - mode: 600
 
+# Fail2ban scans log files for IPs showing signs of malicious
+# behavior and bans them from further access.
 fail2ban:
   pkg.latest:
     - name: fail2ban
 
+# When an IP is banned by Fail2ban, it is put in "jail". The jailing
+# of an IP can be configured with files in this directory.
 /etc/fail2ban/jail.d/:
   file.directory:
     - user: root
@@ -26,6 +30,15 @@ fail2ban:
     - require_in:
       - file: /etc/fail2ban/jail.d/wordpress.conf
 
+# We manage a jail configuration specific to handling failed WordPress
+# authentication attempts.
+/etc/fail2ban/jail.d/wordpress.conf:
+  file.managed:
+    - source: salt://config/fail2ban/jail.wordpress.conf
+
+# To determine which IPs should be bailed, Fail2ban runs logs through
+# filters. The filtering of a log file can be configured with files
+# in this directory.
 /etc/fail2ban/filter.d/:
   file.directory:
     - user: root
@@ -36,15 +49,13 @@ fail2ban:
     - require_in:
       - file: /etc/fail2ban/filter.d/wordpress.conf
 
+# We manage a filter configuration specific to handling logs created by
+# authentication in WordPRess.
 /etc/fail2ban/filter.d/wordpress.conf:
   file.managed:
     - source: salt://config/fail2ban/filter.wordpress.conf
 
-/etc/fail2ban/jail.d/wordpress.conf:
-  file.managed:
-    - source: salt://config/fail2ban/jail.wordpress.conf
-
-# Start the fail2ban service as root.
+# Use fail2ban-client to start fail2ban-server as a proper user.
 fail2ban-init:
   cmd.run:
     - name: fail2ban-client start

--- a/provision/salt/wsuwp.sls
+++ b/provision/salt/wsuwp.sls
@@ -171,6 +171,6 @@ wsuwp-nginx-conf:
 # Flush the web services to ensure object and opcode cache are clear and that nginx configs are processed.
 wsuwp-indie-flush:
   cmd.run:
-    - name: sudo service memcached restart && sudo service nginx restart && sudo service php-fpm restart
+    - name: sudo service memcached restart && sudo service nginx restart && sudo service php-fpm restart && fail2ban-client reload
     - require:
       - cmd: wsuwp-nginx-conf


### PR DESCRIPTION
When fail2ban is started as a service, it does not have the right permissions to manage routes.