### PR TITLE
[PR] Update MySQL and WordPress DB config to use utf8mb4

### DIFF
--- a/provision/salt/config/mysql/my.cnf.jinja
+++ b/provision/salt/config/mysql/my.cnf.jinja
@@ -7,6 +7,7 @@
 [client]
 port    = 3306
 socket  = /var/lib/mysql/mysql.sock
+default-character-set = utf8mb4
 
 # This was formally known as [safe_mysqld]. Both versions are currently parsed.
 [mysqld_safe]
@@ -27,6 +28,8 @@ datadir         = /var/lib/mysql
 tmpdir          = /tmp
 lc-messages-dir	= /usr/share/mysql
 skip-external-locking
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
 
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
@@ -74,6 +77,7 @@ quote-names
 max_allowed_packet = 16M
 
 [mysql]
+default-character-set = utf8mb4
 
 [isamchk]
 key_buffer = 16M

--- a/provision/salt/config/wordpress/wp-config.php.jinja
+++ b/provision/salt/config/wordpress/wp-config.php.jinja
@@ -68,9 +68,9 @@ define( 'DISALLOW_FILE_MODS', false );
 
 $table_prefix  = 'wp_';
 
-define( 'DB_CHARSET', 'utf8' );
-define( 'DB_COLLATE', ''     );
-define( 'WPLANG',     ''     );
+define( 'DB_CHARSET', 'utf8mb4' );
+define( 'DB_COLLATE', 'utf8mb4_unicode_ci' );
+define( 'WPLANG', '' );
 
 /** Sets up WordPress vars and included files. */
 require_once( ABSPATH . 'wp-settings.php' );

--- a/provision/salt/config/wordpress/wsuwp-wp-config.php.jinja
+++ b/provision/salt/config/wordpress/wsuwp-wp-config.php.jinja
@@ -72,9 +72,9 @@ define( 'DISALLOW_FILE_MODS', true );
 
 $table_prefix  = 'wp_';
 
-define( 'DB_CHARSET', 'utf8' );
-define( 'DB_COLLATE', ''     );
-define( 'WPLANG',     ''     );
+define( 'DB_CHARSET', 'utf8mb4' );
+define( 'DB_COLLATE', 'utf8mb4_unicode_ci' );
+define( 'WPLANG', '' );
 
 /** Sets up WordPress vars and included files. */
 require_once( ABSPATH . 'wp-settings.php' );


### PR DESCRIPTION
WordPress 4.2 will automatically upgrade utf8 tables to utf8mb4.

wsuwp-prod-01 has already been upgraded, this config is set to
match. Other individual WordPress sites will be updated automatically