### PR TITLE
[PR] Set the default munin directory to /var/www/html/munin for prod

### DIFF
--- a/provision/salt/config/munin/munin.conf
+++ b/provision/salt/config/munin/munin.conf
@@ -6,7 +6,7 @@
 # defaulted to the values you see here.
 #
 dbdir   /var/lib/munin
-htmldir /var/www-munin
+htmldir /var/www/html/munin
 logdir /var/log/munin
 rundir  /var/run/munin
 


### PR DESCRIPTION
This will break local development, but we'll probably exclude it
at some point anyway.