### PR TITLE
[PR] Use HTTP for Pagespeed from Google instead of HTTPS

### DIFF
--- a/provision/salt/config/nginx/compile-nginx.sh
+++ b/provision/salt/config/nginx/compile-nginx.sh
@@ -15,7 +15,7 @@ cd /tmp/
 wget https://github.com/pagespeed/ngx_pagespeed/archive/v1.9.32.4-beta.zip
 unzip v1.9.32.4-beta
 cd /tmp/ngx_pagespeed-1.9.32.4-beta/
-wget https://dl.google.com/dl/page-speed/psol/1.9.32.4.tar.gz
+wget http://dl.google.com/dl/page-speed/psol/1.9.32.4.tar.gz
 tar -xzvf 1.9.32.4.tar.gz # expands to psol/
 
 # Get the Nginx source.


### PR DESCRIPTION
avoid a temporary cert mismatch