### PR TITLE
[PR] Update the Remi Repo to PHP 5.6

### DIFF
--- a/provision/salt/server.sls
+++ b/provision/salt/server.sls
@@ -39,14 +39,14 @@ remi-repo:
     - baseurl: http://rpms.famillecollet.com/enterprise/6/remi/x86_64/
     - gpgcheck: 0
     - require_in:
-      - pkgrepo: remi-php55-repo
+      - pkgrepo: remi-php56-repo
 
-# Remi has a repository specifically setup for PHP 5.5. This continues
+# Remi has a repository specifically setup for PHP 5.6. This continues
 # to reply on the standard Remi repository for some packages.
-remi-php55-repo:
+remi-php56-repo:
   pkgrepo.managed:
-    - humanname: Remi PHP 5.5 Repository
-    - baseurl: http://rpms.famillecollet.com/enterprise/6/php55/x86_64/
+    - humanname: Remi PHP 5.6 Repository
+    - baseurl: http://rpms.famillecollet.com/enterprise/6/php56/x86_64/
     - gpgcheck: 0
 
 # Use packages from the CentOS plus repository when applicable.


### PR DESCRIPTION
PHP 5.6 has been stable enough to use for a long while, we need to
catch up.