### PR TITLE
[PR] Allow for common nginx configs on WSUWP Indie

### DIFF
--- a/provision/salt/config/nginx/wsuwp-common-listen.conf
+++ b/provision/salt/config/nginx/wsuwp-common-listen.conf
@@ -1,0 +1,1 @@
+listen 443 ssl http2;

--- a/provision/salt/webserver.sls
+++ b/provision/salt/webserver.sls
@@ -154,6 +154,29 @@ php-fpm-init:
     - require:
       - cmd: nginx
 
+# Add a common SSL configuration for nginx
+/etc/nginx/wsuwp-ssl-common.conf:
+  file.managed:
+    - template: jinja
+    - source:   salt://config/nginx/wsuwp-ssl-common.conf
+    - user:     root
+    - group:    root
+    - mode:     644
+    - require:
+      - cmd:    nginx
+
+# Add a common standard configuration for nginx via Jinja template
+# to be used in combination with SSL when necessary.
+/etc/nginx/wsuwp-common.conf:
+  file.managed:
+    - template: jinja
+    - source:   salt://config/nginx/wsuwp-common.conf.jinja
+    - user:     root
+    - group:    root
+    - mode:     644
+    - require:
+      - cmd:    nginx
+
 /etc/nginx/mime.types:
   file.managed:
     - source: salt://config/nginx/mime.types

--- a/provision/salt/wordpress.sls
+++ b/provision/salt/wordpress.sls
@@ -118,6 +118,19 @@ site-dir-setup-{{ site_args['directory'] }}:
 # nginx config is provided manually for this site.
 {% endif %}
 
+# Add a common listen directive for nginx to be used in indie
+# configurations that have different root directories. This header
+# allows us to change the listen and root directives for many sites
+# at a time.
+/etc/nginx/wsuwp-common-listen.conf:
+  file.managed:
+    - source: salt://config/nginx/wsuwp-common-listen.conf
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - cmd: nginx
+
 {% if site_args['wordpress'] == 'disabled' %}
 {% else %}
 # Setup the directories required for a WordPress project inside the

--- a/provision/salt/wsuwp.sls
+++ b/provision/salt/wsuwp.sls
@@ -137,29 +137,6 @@ activate-wsu-spine-theme:
     - require:
       - cmd: enable-wsu-spine-theme
 
-# Add a common SSL configuration for nginx
-/etc/nginx/wsuwp-ssl-common.conf:
-  file.managed:
-    - template: jinja
-    - source:   salt://config/nginx/wsuwp-ssl-common.conf
-    - user:     root
-    - group:    root
-    - mode:     644
-    - require:
-      - cmd:    nginx
-
-# Add a common standard configuration for nginx via Jinja template
-# to be used in combination with SSL when necessary.
-/etc/nginx/wsuwp-common.conf:
-  file.managed:
-    - template: jinja
-    - source:   salt://config/nginx/wsuwp-common.conf.jinja
-    - user:     root
-    - group:    root
-    - mode:     644
-    - require:
-      - cmd:    nginx
-
 # Add a common header for nginx to be used in all generated nginx
 # configurations that load common HTTPS directives. This header
 # allows us to change the listen and root directives for many sites


### PR DESCRIPTION
Creates a new wsuwp-common-listen.conf that only provides the
listen directive. Sites on indie have different root directories
and cannot use the common root provided for WSUWP Prod in
wsuwp-common-header.conf