### PR TITLE
[PR] Update OpenSSL URL

### DIFF
--- a/provision/salt/config/nginx/compile-nginx.sh
+++ b/provision/salt/config/nginx/compile-nginx.sh
@@ -50,7 +50,7 @@ cd /tmp/nginx-1.9.9
 --with-ipv6 \
 --with-cc-opt='-g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2' \
 --with-ld-opt='-Wl,-z,relro -Wl,--as-needed' \
---with-openssl=/tmp/openssl-1.0.2e
+--with-openssl=/tmp/openssl-OpenSSL_1_0_2e
 
 cd /tmp/nginx-1.9.9
 make

--- a/provision/salt/config/nginx/compile-nginx.sh
+++ b/provision/salt/config/nginx/compile-nginx.sh
@@ -6,7 +6,7 @@ rm -fr /tmp/openssl-1.0.2e
 
 # Compile against OpenSSL to enable NPN.
 cd /tmp/
-wget https://openssl.org/source/openssl-1.0.2e.tar.gz
+wget https://github.com/openssl/openssl/archive/OpenSSL_1_0_2e.tar.gz -O openssl-1.0.2e.tar.gz
 tar -xzvf openssl-1.0.2e.tar.gz
 
 # Get the Nginx source.

--- a/provision/salt/config/nginx/default
+++ b/provision/salt/config/nginx/default
@@ -1,40 +1,5 @@
 server {
-    listen       80 default_server;
+    listen       80;
     root         /var/www/html;
-    server_name  _;
-
-    location / {
-        index index.php;
-        try_files $uri $uri/ /index.php?$args;
-    }
-
-    gzip off;
-
-    # Directives to send expires headers and turn off 404 error logging.
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico)$ {
-        expires 24h;
-        log_not_found off;
-    }
-
-    # this prevents hidden files (beginning with a period) from being served
-    location ~ /\.          { access_log off; log_not_found off; deny all; }
-
-    location ~ \.php$ {
-        client_max_body_size 25M;
-        try_files      $uri =404;
-
-        # Include the fastcgi_params defaults provided by nginx
-        include        /etc/nginx/fastcgi_params;
-
-        # SCRIPT_FILENAME is a required parameter for things to work properly,
-        # but is missing in the default fastcgi_params. We define it here to
-        # be sure that it exists.
-        fastcgi_param   SCRIPT_FILENAME         $document_root$fastcgi_script_name;
-
-        # Use the upstream for fastcgi / php5-fpm that we defined in nginx.conf
-        fastcgi_pass   php;
-
-        # And get to serving the file!
-        fastcgi_index  index.php;
-    }
+    return 301 https://wsu.edu;
 }


### PR DESCRIPTION
The certificate used by openssl.org, amusingly enough, isn't working with wget because of the wildcard. We can safely use the github.com URL for the release for the time being.

This also modifies the default server configuration for nginx to just redirect to wsu.edu rather than attempting to provide anything else.