### PR TITLE
[PR] Update the `grep` text for OpenSSL matching for new format

### DIFF
--- a/provision/salt/webserver.sls
+++ b/provision/salt/webserver.sls
@@ -54,7 +54,7 @@ nginx:
   cmd.run:
     - name: sh nginx-compile.sh
     - cwd: /root/
-    - unless: nginx -V &> nginx-version.txt && cat nginx-version.txt | grep -A 42 "nginx/1.9.9" | grep "openssl-1.0.2e"
+    - unless: nginx -V &> nginx-version.txt && cat nginx-version.txt | grep -A 42 "nginx/1.9.9" | grep "OpenSSL_1_0_2e"
     - require:
       - pkg: src-build-prereq
       - file: /root/nginx-compile.sh


### PR DESCRIPTION
When we changed the URL used to download OpenSSL, the directory
name changed as well. We need to match against the correct name
otherwise we'll rebuild nginx every time provisioning is run, even
if it isn't required.