### PR TITLE
[PR] Make policycoreutils-python available to all provisioned servers

### DIFF
--- a/provision/salt/security.sls
+++ b/provision/salt/security.sls
@@ -1,3 +1,7 @@
+policycoreutils-python:
+  pkg.latest:
+    - name: policycoreutils-python
+
 iptables:
   pkg.installed:
     - name: iptables


### PR DESCRIPTION
This allows access to utilities such as `audit2allow`, which help to manage security policies.