### PR TITLE
[PR] Start tracking an selinux config file

### DIFF
--- a/provision/salt/config/selinux/config
+++ b/provision/salt/config/selinux/config
@@ -1,0 +1,10 @@
+# This file controls the state of SELinux on the system.
+# SELINUX= can take one of these three values:
+#     enforcing - SELinux security policy is enforced.
+#     permissive - SELinux prints warnings instead of enforcing.
+#     disabled - No SELinux policy is loaded.
+SELINUX=permissive
+# SELINUXTYPE= can take one of these two values:
+#     targeted - Targeted processes are protected,
+#     mls - Multi Level Security protection.
+SELINUXTYPE=targeted

--- a/provision/salt/security.sls
+++ b/provision/salt/security.sls
@@ -78,6 +78,11 @@ fail2ban-init:
     - require:
       - pkg: fail2ban
 
+# Provide an selinux configuration file to make selinux permissive.
+/etc/selinux/config:
+  file.managed:
+    - source: salt://config/selinux/config
+
 # Provide a notification script to ping Slack with successful SSH authentications.
 /etc/ssh/notify.sh:
   file.managed:


### PR DESCRIPTION
Make selinux permissive by default. We mitigate different attack
areas in many other ways and this ends up being overly obtrusive
when trying to get stuff done.