### PR TITLE
[PR] Disable log_queries_not_using_indexes

### DIFF
--- a/provision/salt/config/mysql/my.cnf.jinja
+++ b/provision/salt/config/mysql/my.cnf.jinja
@@ -68,7 +68,7 @@ log_error = /var/log/mysql/mysql-error.log
 slow_query_log = 1
 slow_query_log_file = /var/log/mysql/mysql-slow.log
 long_query_time = 3
-log_queries_not_using_indexes = 1
+log_queries_not_using_indexes = OFF
 
 expire_logs_days = 10
 max_binlog_size  = 100M


### PR DESCRIPTION
This kind of pollutes the log files. We should spend more time
looking at actual slow queries before we dig into non-indexed
queries.