### PR TITLE
[PR] Provide a WordPress specific default site

### DIFF
--- a/provision/salt/config/nginx/default
+++ b/provision/salt/config/nginx/default
@@ -4,21 +4,3 @@ server {
     set $embed_request 0;
     return 301 https://wsu.edu;
 }
-
-# Provide a default response for *.wsu.edu domains that are requested
-# over HTTPS but do not have a configured certificate. Browsers should
-# show a certificate error. Bots will ignore the certificate error and
-# receive a 404 response.
-server {
-    server_name *.wsu.edu;
-    include /etc/nginx/wsuwp-common-header.conf;
-
-    # This cert will not be valid for any of the requested sites.
-    ssl_certificate     /etc/nginx/ssl/default.wp.wsu.edu.cer;
-    ssl_certificate_key /etc/nginx/ssl/default.wp.wsu.edu.key;
-
-    include /etc/nginx/wsuwp-ssl-common.conf;
-
-    add_header 'Content-Type' 'text/plain charset=UTF-8' always;
-    return 404 'Address not available';
-}

--- a/provision/salt/config/nginx/default-wsuwp
+++ b/provision/salt/config/nginx/default-wsuwp
@@ -1,0 +1,17 @@
+# Provide a default response for *.wsu.edu domains that are requested
+# over HTTPS but do not have a configured certificate. Browsers should
+# show a certificate error. Bots will ignore the certificate error and
+# receive a 404 response.
+server {
+    server_name *.wsu.edu;
+    include /etc/nginx/wsuwp-common-header.conf;
+
+    # This cert will not be valid for any of the requested sites.
+    ssl_certificate     /etc/nginx/ssl/default.wp.wsu.edu.cer;
+    ssl_certificate_key /etc/nginx/ssl/default.wp.wsu.edu.key;
+
+    include /etc/nginx/wsuwp-ssl-common.conf;
+
+    add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+    return 404 'Address not available';
+}

--- a/provision/salt/wsuwp.sls
+++ b/provision/salt/wsuwp.sls
@@ -160,6 +160,15 @@ activate-wsu-spine-theme:
     - require:
       - cmd: nginx
 
+/etc/nginx/sites-enabled/default-wp:
+  file.managed:
+    - source: salt://config/nginx/default-wp
+    - user: root
+    - group: root
+    - mode: 644
+    - require:
+      - cmd: nginx
+
 # Configure Nginx with a jinja template.
 wsuwp-nginx-conf:
   cmd.run:


### PR DESCRIPTION
This won't apply to other nginx servers that do not use the common wsuwp header files.

If this server block is included as part of `default`, servers like uc-proxy-01 will fail provisioning because of a missing WSUWP specific file.