### PR TITLE
[PR] Provide a config for innodb_buffer_pool_instances

### DIFF
--- a/provision/salt/config/mysql/my.cnf.jinja
+++ b/provision/salt/config/mysql/my.cnf.jinja
@@ -51,6 +51,7 @@ table_open_cache    = {{ salt['pillar.get']('mysql-config:table_open_cache', '40
 
 # The InnoDB buffer pool size should be larger than the amount of data if possible.
 innodb_buffer_pool_size = {{ salt['pillar.get']('mysql-config:innodb_buffer_pool_size', '128M') }}
+innodb_buffer_pool_instances = {{ salt['pillar.get']('mysql-config:innodb_buffer_pool_instances', '1' ) }}
 
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched


### PR DESCRIPTION
This is a default of 1 in MySQL already. On servers that have an
innodb buffer pool of more than 1GB it can make sense to have
multiple instances so that concurrent threads can process requests.

On WSUWP, we already have a buffer pool of 4GB (soon 6GB) that can
likely benefit from this setting.