### PR TITLE
[PR] Force a trailing slash on wp-admin URLs

### DIFF
--- a/provision/salt/config/nginx/wsuwp-common.conf.jinja
+++ b/provision/salt/config/nginx/wsuwp-common.conf.jinja
@@ -71,6 +71,7 @@ location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|sh|sql|sw[op])|~)$ {
 
 # Rewrite multisite in a subdirectory '.../wp-.*' and '.../*.php'.
 if (!-e $request_filename) {
+    rewrite /wp-admin$ $scheme://$host$uri/ permanent;
     rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
     rewrite ^/[_0-9a-zA-Z-]+.*(/wp-admin/.*\.php)$ $1 last;
     rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;


### PR DESCRIPTION
This fixes an issue where somebody visiting subsite/wp-admin was redirected to mainsite/wp-admin/ because of this missing slash.