### PR TITLE
[PR] Ensure embed_request is defined in all location blocks

### DIFF
--- a/provision/salt/config/nginx/default
+++ b/provision/salt/config/nginx/default
@@ -10,5 +10,6 @@ server {
 	listen [::]:80 default_server deferred;
 	listen 80 default_server deferred;
 	server_name _;
+	set $embed_request 0;
 	return 444;
 }


### PR DESCRIPTION
This caused an issue after provisioning on wsusearch-prod-01 where nginx would not start due to an invalid config.